### PR TITLE
Fix rent payment amount for owners

### DIFF
--- a/Project Game AntKnow/Assets/Script/Domain/Services/BoardRules.cs
+++ b/Project Game AntKnow/Assets/Script/Domain/Services/BoardRules.cs
@@ -76,10 +76,11 @@ public static class BoardRules {
     return rent;
   }
 
-  public static void PayRent(PlayerState payer, PlayerState owner, int rent) {
+  public static int PayRent(PlayerState payer, PlayerState owner, int rent) {
     int reducePct = payer.Resistance / 100;
     int pay = Math.Max(0, rent - rent * reducePct / 100);
     payer.Money -= pay;
-    owner.Money += rent;
+    owner.Money += pay;
+    return pay;
   }
 }


### PR DESCRIPTION
## Summary
- ensure property owners receive the actual rent that was deducted after resistance adjustments
- expose the actual paid amount from `BoardRules.PayRent` for optional UI consumption

## Testing
- not run (project is Unity-based)


------
https://chatgpt.com/codex/tasks/task_e_68cd2bf009248331adb4d9aae5472c8b