### PR TITLE
Configure server build scenes

### DIFF
--- a/Project Game AntKnow Server/Assets/Settings/Build Profiles/New Linux Server Profile.asset
+++ b/Project Game AntKnow Server/Assets/Settings/Build Profiles/New Linux Server Profile.asset
@@ -18,8 +18,11 @@ MonoBehaviour:
   m_PlatformId: 91d938b35f6f4798811e41f2acf9377f
   m_PlatformBuildProfile:
     rid: 8135802717319462983
-  m_OverrideGlobalSceneList: 0
-  m_Scenes: []
+  m_OverrideGlobalSceneList: 1
+  m_Scenes:
+  - enabled: 1
+    path: Assets/GameScene.unity
+    guid: 43795568f934947279e74f753742b73c
   m_ScriptingDefines: []
   m_PlayerSettingsYaml:
     m_Settings:

--- a/Project Game AntKnow Server/ProjectSettings/EditorBuildSettings.asset
+++ b/Project Game AntKnow Server/ProjectSettings/EditorBuildSettings.asset
@@ -5,10 +5,7 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 0
-    path: Assets/NGO_Minimal_Setup/NGO_Setup.unity
-    guid: d9b435b7ccf7b534c96b400e8b9cf0c1
-  - enabled: 0
+  - enabled: 1
     path: Assets/GameScene.unity
     guid: 43795568f934947279e74f753742b73c
   m_configObjects: {}


### PR DESCRIPTION
## Summary
- enable the dedicated GameScene in the server project's editor build settings
- configure the Linux server build profile to override the scene list with GameScene

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d16fdce5cc83318c81c7c4d8301f6f